### PR TITLE
Fix shell layout by adopting app-layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
     "iron-elements": "PolymerElements/iron-elements#^1.0.10",
     "paper-elements": "PolymerElements/paper-elements#^1.0.7",
     "platinum-elements": "PolymerElements/platinum-elements#^2.0.0",
-    "neon-elements": "PolymerElements/neon-elements#^1.0.0"
+    "neon-elements": "PolymerElements/neon-elements#^1.0.0",
+    "app-layout": "PolymerElements/app-layout#^0.10.3"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/index.html
+++ b/index.html
@@ -1,19 +1,97 @@
 <!doctype html>
 
-<html>
+<!doctype html>
+<html lang="en">
   <head>
-    <title>Symposium</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>Symposium</title>
+    <meta name="description" content="My App description">
+
+    <link rel="icon" href="/images/favicon.ico">
+
+    <!-- See https://goo.gl/OOhYW5 -->
     <link rel="manifest" href="/manifest.json">
-    <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="/src/symposium-app/symposium-app.html">
-    <link rel="import" href="bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 
-    <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
+    <!-- See https://goo.gl/qRE0vM -->
+    <meta name="theme-color" content="#3f51b5">
 
+    <!-- Add to homescreen for Chrome on Android. Fallback for manifest.json -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="My App">
+
+    <!-- Add to homescreen for Safari on iOS -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="My App">
+
+    <!-- Homescreen icons -->
+    <link rel="apple-touch-icon" href="/images/manifest/icon-48x48.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/images/manifest/icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="96x96" href="/images/manifest/icon-96x96.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/images/manifest/icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="/images/manifest/icon-192x192.png">
+
+    <!-- Tile icon for Windows 8 (144x144 + tile color) -->
+    <meta name="msapplication-TileImage" content="/images/manifest/icon-144x144.png">
+    <meta name="msapplication-TileColor" content="#3f51b5">
+    <meta name="msapplication-tap-highlight" content="no">
+
+    <script>
+      // Setup Polymer options
+      window.Polymer = {
+        dom: 'shadow',
+        lazyRegister: true
+      };
+      // Load webcomponentsjs polyfill if browser does not support native Web Components
+      (function() {
+        'use strict';
+        var onload = function() {
+          // For native Imports, manually fire WebComponentsReady so user code
+          // can use the same code path for native and polyfill'd imports.
+          if (!window.HTMLImports) {
+            document.dispatchEvent(
+              new CustomEvent('WebComponentsReady', {bubbles: true})
+            );
+          }
+        };
+        var webComponentsSupported = (
+          'registerElement' in document
+          && 'import' in document.createElement('link')
+          && 'content' in document.createElement('template')
+        );
+        if (!webComponentsSupported) {
+          var script = document.createElement('script');
+          script.async = true;
+          script.src = '/bower_components/webcomponentsjs/webcomponents-lite.min.js';
+          script.onload = onload;
+          document.head.appendChild(script);
+        } else {
+          onload();
+        }
+      })();
+      // Load pre-caching Service Worker
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function() {
+          navigator.serviceWorker.register('service-worker.js');
+        });
+      }
+    </script>
+
+    <link rel="import" href="src/symposium-app/symposium-app.html">
+
+    <style>
+      body {
+        margin: 0;
+        font-family: 'Roboto', 'Noto', sans-serif;
+        line-height: 1.5;
+        min-height: 100vh;
+        background-color: #eeeeee;
+      }
+    </style>
   </head>
-  <body style="margin: 0;">
+  <body>
     <symposium-app></symposium-app>
   </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,1 @@
+console.info('Service worker disabled for development, will be generated at build time.');

--- a/src/symposium-app/symposium-app.html
+++ b/src/symposium-app/symposium-app.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/paper-header-panel/paper-header-panel.html">
-<link rel="import" href="../../bower_components/paper-toolbar/paper-toolbar.html">
+<link rel="import" href="../../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 <link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
@@ -10,7 +10,7 @@
 
 <dom-module id="symposium-app">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;
@@ -21,8 +21,8 @@
       }
     </style>
 
-    <paper-header-panel>
-      <paper-toolbar class="paper-header layout horizontal center">
+    <app-header-layout>
+      <app-toolbar class="paper-header layout horizontal center">
         <div>
           Symposium
         </div>
@@ -32,15 +32,15 @@
           <paper-tab>Tab 2</paper-tab>
           <paper-tab>Tab 3</paper-tab>
         </paper-tabs>
-      </paper-toolbar>
+      </app-toolbar>
 
       <iron-pages selected="{{selected}}">
         <div>page 1</div>
         <div>page 2</div>
         <div>page 3</div>
       </iron-pages>
-    </paper-header-panel> 
-   
+    </app-header-layout>
+
   </template>
 
   <script>


### PR DESCRIPTION
This fixes the weird layout bug that `paper-header-panel` had. Basically `app-layout` is the better version of these paper-elements.

Also updated the index.html with the new PSK2 structure for lazy-loading.

Lastly fixed your service-worker import. Since the file was missing, index.html was served as fallback, generating an error. By creating a dummy file, this error is gone.
