### PR TITLE
Change to correct wide layout boundary

### DIFF
--- a/src/symposium-app/symposium-app.html
+++ b/src/symposium-app/symposium-app.html
@@ -187,7 +187,7 @@
       </app-header-layout>
     </app-drawer-layout>
 
-    <iron-media-query query="min-width: 600px" query-matches="{{wideLayout}}"></iron-media-query>
+    <iron-media-query query="min-width: 800px" query-matches="{{wideLayout}}"></iron-media-query>
 
   </template>
 


### PR DESCRIPTION
Everywhere in the webpage wide layout is defined at 800 pixels, not 600.
